### PR TITLE
Docs: Adicionando template para pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+# 📌 Descrição da PR
+Forneça informações sobre as mudanças realizadas nesta PR, destacando de forma breve o objetivo principal da modificação.
+
+## 🔗 Link da task
+[Clique aqui para acessar o card da tarefa](link...)
+
+#### Tasks relacionadas
+- link
+
+## 📝 Tipo de mudança
+- [ ] Novo recurso (feature)
+- [ ] Correção de bug
+- [ ] Alteração de UI/UX
+- [ ] Alteração de configuração (Gradle, build, etc.)
+- [ ] Refatoração
+- [ ] Alteração crítica (breaking change)
+
+## ⚙️ Como foi testado?
+- Em quais dispositivos/testes foi validado?  
+- Testes unitários, instrumentados ou manuais?  
+- Passos para reproduzir/verificar.
+
+# ✅ Checklist antes do merge
+- [ ] Testado em dispositivos físicos.
+- [ ] UI revisada conforme guia de design.
+- [ ] Testes passam.
+- [ ] Sem credenciais ou dados sensíveis.
+- [ ] Documentação atualizada (README).


### PR DESCRIPTION
Foi criada a pasta `.github` contendo o arquivo `pull_request_template.md`, que define o template padrão para as Pull Requests deste repositório.
O objetivo é padronizar as descrições das PRs, garantindo maior clareza e qualidade.